### PR TITLE
fix: :bug: page reload bug fix

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs10
+runtime: nodejs16
 service: adinfo-interface-estable
 handlers:
 - url: /(.+\.js)
@@ -18,7 +18,7 @@ handlers:
   upload: index.html
   secure: always
   redirect_http_response_code: 301
-  
+
 - url: /
   static_files: index.html
   upload: index.html


### PR DESCRIPTION
Page redirect should always be to index.js in SPA.

**Ref**: https://stackoverflow.com/questions/39944208/app-engine-on-page-refresh-gives-404-for-my-angular2-project