### PR TITLE
feat: inclusão da mensagem de erro 404 na tela de login.

### DIFF
--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -99,8 +99,11 @@ export default {
                 localStorage.setItem('permission', JSON.parse(data.responseText).permission);
                 this.redirect();
             }).catch((err) => {
-                console.log(err);
                 this.apiErrorMessage = err.message;
+                console.log(err);
+                if(statusCode === 404) {
+                    this.apiErrorMessage = "Não foi possível se conectar à API do Adinfo"
+                }
                 this.showAuthAlert = this.isAuthError(statusCode);
             }).finally(() => {
                 this.show_load = false


### PR DESCRIPTION
em Login.vue inclui a mensagem "Não foi possível se conectar à API do Adinfo" via condicional, caso houver um erro 404 a mensagem será retornada na pagina de Login.