### PR TITLE
correção do link de apontamento da api.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -13,7 +13,7 @@ Vue.use(VueRouter);
 Vue.use(VueMaterial);
 Vue.use(Vuelidate);
 
-Vue.prototype.$apiRoute = 'https://adinfo-api-dot-dev-samsung-hhp.uk.r.appspot.com/';
+Vue.prototype.$apiRoute = 'Link de apontamento para api';
 // Vue.prototype.$apiRoute = 'http://localhost:8000';
 
 const router = new VueRouter({


### PR DESCRIPTION
o link que estava indicado apontava para um ambiente de samsung (alguém de samsung fez um commit e isso acabou vindo para a main) na doc consta a orientação de troca de link de apontamento.